### PR TITLE
Refactor(crypt): Improve RSA safety and flexibility

### DIFF
--- a/pkg/crypt/crypt.go
+++ b/pkg/crypt/crypt.go
@@ -137,17 +137,27 @@ func (s *Service) Fletcher64(payload string) uint64 {
 
 // --- RSA ---
 
+// ensureRSA initializes the RSA service if it is not already.
+func (s *Service) ensureRSA() {
+	if s.rsa == nil {
+		s.rsa = rsa.NewService()
+	}
+}
+
 // GenerateRSAKeyPair creates a new RSA key pair.
 func (s *Service) GenerateRSAKeyPair(bits int) (publicKey, privateKey []byte, err error) {
+	s.ensureRSA()
 	return s.rsa.GenerateKeyPair(bits)
 }
 
 // EncryptRSA encrypts data with a public key.
-func (s *Service) EncryptRSA(publicKey, data []byte) ([]byte, error) {
-	return s.rsa.Encrypt(publicKey, data)
+func (s *Service) EncryptRSA(publicKey, data, label []byte) ([]byte, error) {
+	s.ensureRSA()
+	return s.rsa.Encrypt(publicKey, data, label)
 }
 
 // DecryptRSA decrypts data with a private key.
-func (s *Service) DecryptRSA(privateKey, ciphertext []byte) ([]byte, error) {
-	return s.rsa.Decrypt(privateKey, ciphertext)
+func (s *Service) DecryptRSA(privateKey, ciphertext, label []byte) ([]byte, error) {
+	s.ensureRSA()
+	return s.rsa.Decrypt(privateKey, ciphertext, label)
 }

--- a/pkg/crypt/std/rsa/rsa_test.go
+++ b/pkg/crypt/std/rsa/rsa_test.go
@@ -17,9 +17,9 @@ func TestRSA_Good(t *testing.T) {
 
 	// Encrypt and decrypt a message
 	message := []byte("Hello, World!")
-	ciphertext, err := s.Encrypt(pubKey, message)
+	ciphertext, err := s.Encrypt(pubKey, message, nil)
 	assert.NoError(t, err)
-	plaintext, err := s.Decrypt(privKey, ciphertext)
+	plaintext, err := s.Decrypt(privKey, ciphertext, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, message, plaintext)
 }
@@ -33,9 +33,13 @@ func TestRSA_Bad(t *testing.T) {
 	_, otherPrivKey, err := s.GenerateKeyPair(2048)
 	assert.NoError(t, err)
 	message := []byte("Hello, World!")
-	ciphertext, err := s.Encrypt(pubKey, message)
+	ciphertext, err := s.Encrypt(pubKey, message, nil)
 	assert.NoError(t, err)
-	_, err = s.Decrypt(otherPrivKey, ciphertext)
+	_, err = s.Decrypt(otherPrivKey, ciphertext, nil)
+	assert.Error(t, err)
+
+	// Key size too small
+	_, _, err = s.GenerateKeyPair(512)
 	assert.Error(t, err)
 }
 
@@ -43,8 +47,8 @@ func TestRSA_Ugly(t *testing.T) {
 	s := NewService()
 
 	// Malformed keys and messages
-	_, err := s.Encrypt([]byte("not-a-key"), []byte("message"))
+	_, err := s.Encrypt([]byte("not-a-key"), []byte("message"), nil)
 	assert.Error(t, err)
-	_, err = s.Decrypt([]byte("not-a-key"), []byte("message"))
+	_, err = s.Decrypt([]byte("not-a-key"), []byte("message"), nil)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This commit introduces several improvements to the RSA implementation:

- Preserves zero-value service safety by lazily initializing the RSA service in `pkg/crypt/crypt.go`.
- Enforces a minimum RSA key size of 2048 bits in `pkg/crypt/std/rsa/rsa.go` to prevent the generation of insecure keys.
- Exposes the OAEP label parameter in `Encrypt` and `Decrypt` functions, allowing for more advanced use cases.
- Adds a test case to verify that `GenerateKeyPair` correctly rejects key sizes below the new minimum.