### PR TITLE
feat(tests): Add internal tests for private functions

### DIFF
--- a/pkg/crypt/crypt_internal_test.go
+++ b/pkg/crypt/crypt_internal_test.go
@@ -1,0 +1,24 @@
+package crypt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnsureRSA_Good(t *testing.T) {
+	s := &Service{}
+	assert.Nil(t, s.rsa, "s.rsa should be nil initially")
+	s.ensureRSA()
+	assert.NotNil(t, s.rsa, "s.rsa should not be nil after ensureRSA()")
+}
+
+func TestEnsureRSA_Bad(t *testing.T) {
+	// Not really a "bad" case here in terms of invalid input,
+	// but we can test that calling it twice is safe.
+	s := &Service{}
+	s.ensureRSA()
+	rsaInstance := s.rsa
+	s.ensureRSA()
+	assert.Same(t, rsaInstance, s.rsa, "s.rsa should be the same instance after second call")
+}

--- a/pkg/crypt/std/lthn/lthn_internal_test.go
+++ b/pkg/crypt/std/lthn/lthn_internal_test.go
@@ -1,0 +1,37 @@
+package lthn
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateSalt_Good(t *testing.T) {
+	// "hello" reversed: "olleh" -> "0113h"
+	expected := "0113h"
+	actual := createSalt("hello")
+	assert.Equal(t, expected, actual, "Salt should be correctly created for 'hello'")
+}
+
+func TestCreateSalt_Bad(t *testing.T) {
+	// Test with an empty string
+	expected := ""
+	actual := createSalt("")
+	assert.Equal(t, expected, actual, "Salt for an empty string should be empty")
+}
+
+func TestCreateSalt_Ugly(t *testing.T) {
+	// Test with characters not in the keyMap
+	input := "world123"
+	// "world123" reversed: "321dlrow" -> "e2ld1r0w"
+	expected := "e2ld1r0w"
+	actual := createSalt(input)
+	assert.Equal(t, expected, actual, "Salt should handle characters not in the keyMap")
+
+	// Test with only characters in the keyMap
+	input = "oleta"
+	// "oleta" reversed: "atelo" -> "47310"
+	expected = "47310"
+	actual = createSalt(input)
+	assert.Equal(t, expected, actual, "Salt should correctly handle strings with only keyMap characters")
+}


### PR DESCRIPTION
Adds `_internal_test.go` files to test unexported functions in the `crypt` and `lthn` packages, improving overall test coverage.

- Adds tests for the `ensureRSA` private function in `pkg/crypt/crypt.go`.
- Adds tests for the `createSalt` private function in `pkg/crypt/std/lthn/lthn.go`.

These changes align with the project's TDD methodology and follow the `_Good`, `_Bad`, `_Ugly` testing structure.